### PR TITLE
Add scale label for sensors

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -67,7 +67,8 @@ class TelldusLiveCollector(object):
                     m_name = measurement['name']
                     metric_name = 'telldus_sensor'
                     _add_metric(sensor_metric, metric_name, float(measurement['value']),
-                            labels={'client_name': c_name, 'sensor_name': s_name, 'metric_name': m_name}
+                            labels={'client_name': c_name, 'sensor_name': s_name, 'metric_name': m_name,
+                                    'sensor_scale': measurement['scale']}
                         )
 
         yield sensor_metric


### PR DESCRIPTION
Scale sometimes determine sensor type and should therefore be included as a label.

Example:
SCALE_POWER_KWH: 0 "kWh"
SCALE_POWER_KVAH: 1 "kVAh"
SCALE_POWER_WATT: 2 "W"
SCALE_POWER_PULSE: 3 ""
SCALE_POWER_VOLT: 4 "V"
SCALE_POWER_AMPERE: 5 "A"
SCALE_POWER_POWERFACTOR: 6 ""